### PR TITLE
Fix TF cycle error

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ output "efs_backup_security_group" {
 
 ### `datapipeline_config` variables
 
-|  Name                              |  Default       |  Description                                                | Required |
-|:-----------------------------------|:--------------:|:------------------------------------------------------------|:--------:|
-| instance_type                      | `t2.micro`     | Instance type to use                                        | Yes      |
-| email                              | ``             | Email to use in `SNS`                                       | Yes      |
-| period                             | `24 hours`     | Frequency of pipeline execution (frequency of backups)      | Yes      |
-| timeout                            | `60 Minutes`   | Pipeline execution timeout                                  | Yes      |
+|  Name                              |  Default       |  Description                                                                 | Required |
+|:-----------------------------------|:--------------:|:-----------------------------------------------------------------------------|:--------:|
+| instance_type                      | `t2.micro`     | Instance type to use                                                         | Yes      |
+| email                              | ``             | Email to use in `SNS`. Needs to be provided, otherwise the module will fail  | Yes      |
+| period                             | `24 hours`     | Frequency of pipeline execution (frequency of backups)                       | Yes      |
+| timeout                            | `60 Minutes`   | Pipeline execution timeout                                                   | Yes      |
 
 
 

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,3 @@
-terraform {
-  required_version = ">= 0.9.1"
-}
-
-provider "aws" {
-  region = "${signum(length(var.region)) == 1 ? var.region : data.aws_region.default.name}"
-}
-
 data "aws_region" "default" {
   current = true
 }


### PR DESCRIPTION
## What

* Remove `provider "aws"`
* Updated `README.md`


## Why

* `provider "aws"` needs to be used from a top-level module. This module is a lower-level module

* `provider "aws"` causes cycles in `terraform plan` and `terraform apply`, throwing the error:
> Error asking for user input: 1 error(s) occurred: Cycle: module.efs_backup.data.aws_region.default, module.efs_backup.provider.aws


* `email` is required in `datapipeline_config`. Otherwise the module fails with the error:
> 1 error(s) occurred:
aws_cloudformation_stack.sns: ROLLBACK_COMPLETE: ["The following resource(s) failed to create: [Topic]. . Rollback requested by user." "Invalid parameter: Endpoint"]
