### PR TITLE
Properly Handle AWS S3 Sync Exit Codes

### DIFF
--- a/templates/datapipeline.yml
+++ b/templates/datapipeline.yml
@@ -114,7 +114,9 @@ Resources:
                 # We need to return 0 in this case for the pipeline to succeed because all normal files were synched successfully
                 # http://docs.aws.amazon.com/cli/latest/topic/return-codes.html
                 # https://github.com/aws/aws-cli/issues/1125
-                if [ "$backup_status" -eq "2" ]; then backup_status="0"; fi
+                if [ "$backup_status" -eq "2" ]; then
+                  backup_status="0"
+                fi
                 exit "$backup_status"
             - Key: scriptArgument
               StringValue: "#{myEFSHost}"

--- a/templates/datapipeline.yml
+++ b/templates/datapipeline.yml
@@ -109,6 +109,12 @@ Resources:
                 fi
                 sudo aws s3 sync --delete --exact-timestamps /backup/ s3://$destination/
                 backup_status="$?"
+                # Return code 2 means that the following were skipped:
+                # files/symlinks that do not exist, files that are character special devices, block special device, FIFO's, or sockets, and files that the user cannot read from
+                # We need to return 0 in this case for the pipeline to succeed because all normal files were synched successfully
+                # http://docs.aws.amazon.com/cli/latest/topic/return-codes.html
+                # https://github.com/aws/aws-cli/issues/1125
+                if [ "$backup_status" -eq "2" ]; then backup_status="0"; fi
                 exit "$backup_status"
             - Key: scriptArgument
               StringValue: "#{myEFSHost}"


### PR DESCRIPTION
## What

* `datapipeline.yml` `aws s3 sync`: if return code is 2, then return 0 for the pipeline to succeed


## Why

* Some applications (_e.g._ `Jenkins`) use symlinks that point to non-existing locations. `aws s3 sync` skips them and returns status code `2`. Status code `2` is just a warning, but `DataPipeline` considers it an error resulting in the backup status `Failed`

> warning: Skipping file /backup/jobs/WWWWW/builds/lastSuccessfulBuild. File does not exist. warning: Skipping file /backup/jobs/WWWWW/builds/lastUnstableBuild. File does not exist. warning: Skipping file /backup/jobs/WWWWW/builds/lastFailedBuild. File does not exist. warning: Skipping file /backup/jobs/WWWWW/builds/lastUnsuccessfulBuild. File does not exist. warning: Skipping file /backup/jobs/WWWWW/builds/lastStableBuild. File does not exist.

> Return code 2 can mean at least one or more files marked for transfer were skipped during the transfer process. However, all other files marked for transfer were successfully transferred. Files that are skipped during the transfer process include: files that do not exist, files that are character special devices, block special device, FIFO's, or sockets, and files that the user cannot read from.


## References

* http://docs.aws.amazon.com/cli/latest/topic/return-codes.html
* https://github.com/aws/aws-cli/issues/1125
