### PR TITLE
Fix for the "Invalid parameter: Endpoint" bug

### DIFF
--- a/templates/sns.yml
+++ b/templates/sns.yml
@@ -11,8 +11,9 @@ Resources:
     Type: AWS::SNS::Topic
     Properties:
       Subscription:
-        - Protocol: email
+        -
           Endpoint: !Ref Email
+          Protocol: email
 
 Outputs:
   TopicArn:


### PR DESCRIPTION
During a creation of the module, such error occurs:

`ROLLBACK_COMPLETE: ["The following resource(s) failed to create: [Topic]. . Rollback requested by user." "Invalid parameter: Endpoint"]`

This is a fix for that.