### PR TITLE
Corrected typo in SNS notification "Alart" -> "Alert"

### DIFF
--- a/templates/datapipeline.yml
+++ b/templates/datapipeline.yml
@@ -151,7 +151,7 @@ Resources:
             - Key: topicArn
               StringValue: "#{myTopicArn}"
             - Key: subject
-              StringValue: "[Alart] EFS Backup Failed"
+              StringValue: "[Alert] EFS Backup Failed"
             - Key: message
               StringValue: |
                 scheduledStartTime: "#{node.@scheduledStartTime}"


### PR DESCRIPTION
## what
* "Alert" was misspelled in the failure notification.

## why
* Typo