### PR TITLE
Remove allowed values for EC2 instance types

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Cloud Posse, LLC
+   Copyright 2017-2018 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/templates/datapipeline.yml
+++ b/templates/datapipeline.yml
@@ -161,34 +161,12 @@ Resources:
       ParameterObjects:
         - Id: myInstanceType
           Attributes:
+            - Key: description
+              StringValue: Instance type for performing the restore.
             - Key: type
               StringValue: String
             - Key: default
-              StringValue: t2.nano
-            - Key: description
-              StringValue: Instance type for performing the restore.
-            - Key: allowedValues
-              StringValue: t2.nano
-            - Key: allowedValues
               StringValue: t2.micro
-            - Key: allowedValues
-              StringValue: m3.medium
-            - Key: allowedValues
-              StringValue: m3.large
-            - Key: allowedValues
-              StringValue: m3.xlarge
-            - Key: allowedValues
-              StringValue: m3.2xlarge
-            - Key: allowedValues
-              StringValue: c3.large
-            - Key: allowedValues
-              StringValue: c3.xlarge
-            - Key: allowedValues
-              StringValue: c3.2xlarge
-            - Key: allowedValues
-              StringValue: c3.4xlarge
-            - Key: allowedValues
-              StringValue: c3.8xlarge
         - Id: myExecutionTimeout
           Attributes:
             - Key: type


### PR DESCRIPTION
## what
* Removed `AllowedValues ` for EC2 instance types

## why
* Allowed instance types are optional parameters
* If we use a list of instance type to restrict the values, we'll have to support and update it every time AWS releases new instances

## references
* https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/parameters-section-structure.html
