### PR TITLE
Add `name` to `aws_security_group`

### DIFF
--- a/security_group.tf
+++ b/security_group.tf
@@ -1,6 +1,7 @@
 resource "aws_security_group" "datapipeline" {
   tags        = "${module.label.tags}"
   vpc_id      = "${data.aws_vpc.default.id}"
+  name        = "${module.label.id}"
   description = "${module.label.id}"
 
   ingress {


### PR DESCRIPTION
## what
* Added `name` to `aws_security_group`

## why
* `name` was missing and was auto-generated by Terraform
