### PR TITLE
Remove -resource-role tag from resource role

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -17,7 +17,7 @@ module "resource_role_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
-  attributes = ["${compact(concat(var.attributes, list("resource-role")))}"]
+  attributes = "${var.attributes}"
   tags       = "${var.tags}"
 }
 


### PR DESCRIPTION
## what
* Remove `-resource-role` 

## why
* Does not contribute more information
* Causes name to get very long

## references
* cloudposse/terraform-aws-jenkins#35.