### PR TITLE
Subnet ID as variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,6 @@ Available targets:
   lint                                Lint terraform code
 
 ```
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -163,6 +162,7 @@ Available targets:
 | region | (Optional) AWS Region. If not specified, will be derived from 'aws_region' data source | string | `` | no |
 | ssh_key_pair | `SSH` key that will be deployed on DataPipeline's instance | string | - | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
+| subnet_id | Optionally specify the subnet to use | string | `` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | use_ip_address | If set to `true`, will use IP address instead of DNS name to connect to the `EFS` | string | `false` | no |
 | vpc_id | VPC ID | string | `` | no |
@@ -265,7 +265,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2018 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2019 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/cloudformation.tf
+++ b/cloudformation.tf
@@ -35,7 +35,7 @@ resource "aws_cloudformation_stack" "datapipeline" {
 
   parameters {
     myInstanceType             = "${var.datapipeline_config["instance_type"]}"
-    mySubnetId                 = "${data.aws_subnet_ids.default.ids[0]}"
+    mySubnetId                 = "${var.subnet_id == "" ? data.aws_subnet_ids.default.ids[0] : var.subnet_id}"
     mySecurityGroupId          = "${aws_security_group.datapipeline.id}"
     myEFSHost                  = "${var.use_ip_address == "true" ? data.aws_efs_mount_target.default.ip_address : format("%s.efs.%s.amazonaws.com", data.aws_efs_mount_target.default.file_system_id, (signum(length(var.region)) == 1 ? var.region : data.aws_region.default.name))}"
     myS3BackupsBucket          = "${aws_s3_bucket.backups.id}"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,4 +1,3 @@
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -14,6 +13,7 @@
 | region | (Optional) AWS Region. If not specified, will be derived from 'aws_region' data source | string | `` | no |
 | ssh_key_pair | `SSH` key that will be deployed on DataPipeline's instance | string | - | yes |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
+| subnet_id | Optionally specify the subnet to use | string | `` | no |
 | tags | Additional tags (e.g. `map('BusinessUnit`,`XYZ`) | map | `<map>` | no |
 | use_ip_address | If set to `true`, will use IP address instead of DNS name to connect to the `EFS` | string | `false` | no |
 | vpc_id | VPC ID | string | `` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -78,3 +78,9 @@ variable "tags" {
   default     = {}
   description = "Additional tags (e.g. `map('BusinessUnit`,`XYZ`)"
 }
+
+variable "subnet_id" {
+  type        = "string"
+  default     = ""
+  description = "Optionally specify the subnet to use"
+}


### PR DESCRIPTION
I found that the data pipeline had ended up using a private subnet - I think it just picked the one whose subnet ID came first when sorted - and this meant the instances just got stuck in the "waiting for runner" state.

The default behaviour remains the same, but allows a subnet ID to be passed in. In my case, I could now specify a public subnet and the pipeline ran successfully.