### PR TITLE
Make email optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ Available targets:
 | datapipeline_ids | Datapipeline ids |
 | logs_bucket_name | Logs bucket name |
 | security_group_id | Security group id |
+| sns_topic_arn | Backup notification SNS topic ARN |
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -26,4 +26,5 @@
 | datapipeline_ids | Datapipeline ids |
 | logs_bucket_name | Logs bucket name |
 | security_group_id | Security group id |
+| sns_topic_arn | Backup notification SNS topic ARN |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output "security_group_id" {
   value       = "${aws_security_group.datapipeline.id}"
   description = "Security group id"
 }
+
+output "sns_topic_arn" {
+  value       = "${aws_cloudformation_stack.sns.outputs.TopicArn}"
+  description = "Backup notification SNS topic ARN"
+}

--- a/templates/sns.yml
+++ b/templates/sns.yml
@@ -6,13 +6,20 @@ Parameters:
   Email:
     Type: String
 
+Conditions:
+  SubscribeEmail: !Not [!Equals [ !Ref Email, ""]]
+
 Resources:
   Topic:
     Type: AWS::SNS::Topic
+
+  EmailSubscription:
+    Condition: SubscribeEmail
+    Type: AWS::SNS::Subscription
     Properties:
-      Subscription:
-        - Protocol: email
-          Endpoint: !Ref Email
+      TopicArn: !Ref Topic
+      Protocol: email
+      Endpoint: !Ref Email
 
 Outputs:
   TopicArn:


### PR DESCRIPTION
I found that the SNS cloudformation stack errored if I tried to set email to be `""`. This makes it so the cloudformation stack can handle email being empty.

This also adds the topic ARN as an output, so you can link it up to whatever you choose.