### PR TITLE
Allow setting datapipeline security group

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Available targets:
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `efs-backup`) | list | `<list>` | no |
 | datapipeline_config | DataPipeline configuration options | map | `<map>` | no |
+| datapipeline_security_group | Optionally specify a security group to use for the datapipeline instances | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | efs_mount_target_id | EFS Mount Target ID (e.g. `fsmt-279bfc62`) | string | - | yes |
 | modify_security_group | Should the module modify the `EFS` security group | string | `false` | no |

--- a/cloudformation.tf
+++ b/cloudformation.tf
@@ -36,7 +36,7 @@ resource "aws_cloudformation_stack" "datapipeline" {
   parameters {
     myInstanceType             = "${var.datapipeline_config["instance_type"]}"
     mySubnetId                 = "${var.subnet_id == "" ? data.aws_subnet_ids.default.ids[0] : var.subnet_id}"
-    mySecurityGroupId          = "${var.datapipeline_security_group == "" ? join(" ", aws_security_group.datapipeline.*.id) : var.datapipeline_security_group}"
+    mySecurityGroupId          = "${var.datapipeline_security_group == "" ? join("", aws_security_group.datapipeline.*.id) : var.datapipeline_security_group}"
     myEFSHost                  = "${var.use_ip_address == "true" ? data.aws_efs_mount_target.default.ip_address : format("%s.efs.%s.amazonaws.com", data.aws_efs_mount_target.default.file_system_id, (signum(length(var.region)) == 1 ? var.region : data.aws_region.default.name))}"
     myS3BackupsBucket          = "${aws_s3_bucket.backups.id}"
     myRegion                   = "${signum(length(var.region)) == 1 ? var.region : data.aws_region.default.name}"

--- a/cloudformation.tf
+++ b/cloudformation.tf
@@ -36,7 +36,7 @@ resource "aws_cloudformation_stack" "datapipeline" {
   parameters {
     myInstanceType             = "${var.datapipeline_config["instance_type"]}"
     mySubnetId                 = "${var.subnet_id == "" ? data.aws_subnet_ids.default.ids[0] : var.subnet_id}"
-    mySecurityGroupId          = "${aws_security_group.datapipeline.id}"
+    mySecurityGroupId          = "${var.datapipeline_security_group == "" ? join(" ", aws_security_group.datapipeline.*.id) : var.datapipeline_security_group}"
     myEFSHost                  = "${var.use_ip_address == "true" ? data.aws_efs_mount_target.default.ip_address : format("%s.efs.%s.amazonaws.com", data.aws_efs_mount_target.default.file_system_id, (signum(length(var.region)) == 1 ? var.region : data.aws_region.default.name))}"
     myS3BackupsBucket          = "${aws_s3_bucket.backups.id}"
     myRegion                   = "${signum(length(var.region)) == 1 ? var.region : data.aws_region.default.name}"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,6 +4,7 @@
 |------|-------------|:----:|:-----:|:-----:|
 | attributes | Additional attributes (e.g. `efs-backup`) | list | `<list>` | no |
 | datapipeline_config | DataPipeline configuration options | map | `<map>` | no |
+| datapipeline_security_group | Optionally specify a security group to use for the datapipeline instances | string | `` | no |
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | string | `-` | no |
 | efs_mount_target_id | EFS Mount Target ID (e.g. `fsmt-279bfc62`) | string | - | yes |
 | modify_security_group | Should the module modify the `EFS` security group | string | `false` | no |

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,7 @@ output "datapipeline_ids" {
 }
 
 output "security_group_id" {
-  value       = "${aws_security_group.datapipeline.id}"
+  value       = "${var.datapipeline_security_group == "" ? join(" ", aws_security_group.datapipeline.*.id) : var.datapipeline_security_group}"
   description = "Security group id"
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -14,7 +14,7 @@ output "datapipeline_ids" {
 }
 
 output "security_group_id" {
-  value       = "${var.datapipeline_security_group == "" ? join(" ", aws_security_group.datapipeline.*.id) : var.datapipeline_security_group}"
+  value       = "${var.datapipeline_security_group == "" ? join("", aws_security_group.datapipeline.*.id) : var.datapipeline_security_group}"
   description = "Security group id"
 }
 

--- a/security_group.tf
+++ b/security_group.tf
@@ -27,5 +27,5 @@ resource "aws_security_group_rule" "datapipeline_efs_ingress" {
   security_group_id        = "${data.aws_efs_mount_target.default.security_groups[0]}"
   to_port                  = 0
   type                     = "ingress"
-  source_security_group_id = "${var.datapipeline_security_group == "" ? join(" ", aws_security_group.datapipeline.*.id) : var.datapipeline_security_group}"
+  source_security_group_id = "${var.datapipeline_security_group == "" ? join("", aws_security_group.datapipeline.*.id) : var.datapipeline_security_group}"
 }

--- a/security_group.tf
+++ b/security_group.tf
@@ -1,4 +1,5 @@
 resource "aws_security_group" "datapipeline" {
+  count       = "${var.datapipeline_security_group == "" ? 1 : 0}"
   tags        = "${module.label.tags}"
   vpc_id      = "${data.aws_vpc.default.id}"
   name        = "${module.label.id}"
@@ -26,5 +27,5 @@ resource "aws_security_group_rule" "datapipeline_efs_ingress" {
   security_group_id        = "${data.aws_efs_mount_target.default.security_groups[0]}"
   to_port                  = 0
   type                     = "ingress"
-  source_security_group_id = "${aws_security_group.datapipeline.id}"
+  source_security_group_id = "${var.datapipeline_security_group == "" ? join(" ", aws_security_group.datapipeline.*.id) : var.datapipeline_security_group}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -84,3 +84,9 @@ variable "subnet_id" {
   default     = ""
   description = "Optionally specify the subnet to use"
 }
+
+variable "datapipeline_security_group" {
+  type        = "string"
+  default     = ""
+  description = "Optionally specify a security group to use for the datapipeline instances"
+}


### PR DESCRIPTION
The security group for the datapipeline instances opens SSH to the world (port 22, 0.0.0.0/0), which is not ideal.

Further, I had problems with it always showing changes (I think because I had `modify_security_group = false` and was adding a rule to the SG after the module had run).

This allows a security group to be passed into the module for use on the datapipeline instances. The EFS mount security group must allow traffic from this security group.