### PR TITLE
fix: remove "current" argument from aws_region

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,4 @@
-data "aws_region" "default" {
-  current = true
-}
+data "aws_region" "default" {}
 
 module "label" {
   source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.1"

--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,6 @@ output "security_group_id" {
 }
 
 output "sns_topic_arn" {
-  value       = "${aws_cloudformation_stack.sns.outputs.TopicArn}"
+  value       = "${aws_cloudformation_stack.sns.outputs["TopicArn"]}"
   description = "Backup notification SNS topic ARN"
 }


### PR DESCRIPTION
Fixes `data.aws_region.default: "current": [REMOVED] Defaults to current provider region if no other filtering is enabled` in aws provider versions 2.x.x

https://www.terraform.io/docs/providers/aws/guides/version-2-upgrade.html#data-source-aws_region